### PR TITLE
Game Board Performance

### DIFF
--- a/src/app_presenter.rb
+++ b/src/app_presenter.rb
@@ -24,7 +24,6 @@ class AppPresenter
   end
 
   def turn_updated(state)
-    @window.each { |child| @window.remove(child) }
     @game_board_view.draw(state[:board_data])
   end
 
@@ -33,6 +32,7 @@ class AppPresenter
     if state[:phase] == AppModel::MENU
       @main_menu_view.draw(state[:type], state[:mode])
     elsif state[:phase] == AppModel::IN_PROGRESS
+      @game_board_view.bind_layout
       @game_board_view.draw(state[:board_data])
     elsif state[:phase] == AppModel::GAME_OVER
       @game_over_view.draw(state[:result])

--- a/src/game_board/game_board_view.rb
+++ b/src/game_board/game_board_view.rb
@@ -18,31 +18,24 @@ class GameBoardView
 
     @token_2_style = Gtk::CssProvider.new
     @token_2_style.load(data: 'button {background-image: image(yellow);}')
-  end
 
-  def draw(board_data)
-    layout = Gtk::Fixed.new
+    @cells = Array.new(6) { Array.new(7, nil) }
+    @layout = Gtk::Fixed.new
 
     cell_grid = Gtk::Grid.new
-    layout.put(cell_grid, 0, 0)
+    @layout.put(cell_grid, 0, 0)
 
     (0..6).each do |col|
       (0..5).each do |row|
         cell = Gtk::Button.new
         cell.set_size_request(100, 100)
-        if (board_data[row][col]).zero?
-          cell.style_context.add_provider(@empty_token_style, Gtk::StyleProvider::PRIORITY_USER)
-        elsif board_data[row][col] == 1
-          cell.style_context.add_provider(@token_1_style, Gtk::StyleProvider::PRIORITY_USER)
-        elsif board_data[row][col] == 2
-          cell.style_context.add_provider(@token_2_style, Gtk::StyleProvider::PRIORITY_USER)
-        end
+        @cells[row][col] = cell
         cell_grid.attach(cell, col, row, 1, 1)
       end
     end
 
     column_grid = Gtk::Grid.new
-    layout.put(column_grid, 0, 0)
+    @layout.put(column_grid, 0, 0)
 
     (0..6).each do |column_index|
       column = Gtk::Button.new
@@ -54,8 +47,25 @@ class GameBoardView
       end
       column_grid.attach(column, column_index, 0, 1, 1)
     end
+  end
 
-    @window.add(layout)
+  def bind_layout
+    @window.add(@layout)
+  end
+
+  def draw(board_data)
+    (0..6).each do |col|
+      (0..5).each do |row|
+        if (board_data[row][col]).zero?
+          @cells[row][col].style_context.add_provider(@empty_token_style, Gtk::StyleProvider::PRIORITY_USER)
+        elsif board_data[row][col] == 1
+          @cells[row][col].style_context.add_provider(@token_1_style, Gtk::StyleProvider::PRIORITY_USER)
+        elsif board_data[row][col] == 2
+          @cells[row][col].style_context.add_provider(@token_2_style, Gtk::StyleProvider::PRIORITY_USER)
+        end
+      end
+    end
+
     @window.show_all
   end
 end


### PR DESCRIPTION
Having to destroy the game board widgets and redraw them each turn was the source of some noticeable input lag. This branch refactors the game board view and app presenter so that the only thing that happens each turn is a repaint of the existing button widgets.